### PR TITLE
Xml tag name filter fix

### DIFF
--- a/lib/XMLElementData.php
+++ b/lib/XMLElementData.php
@@ -69,7 +69,7 @@ class XMLElementData
      */
     public function setName(string $name): XMLElementData
     {
-        $name = preg_replace('/([^a-zA-Z]+)/', '', $name);
+        $name = preg_replace('/([^a-zA-Z\-\_]+)/', '', $name);
 
         $this->name = $name;
         return $this;


### PR DESCRIPTION
https://www.w3schools.com/xml/xml_elements.asp
Element names can contain letters, digits, hyphens, underscores, and periods