### PR TITLE
Loop without extra start tag

### DIFF
--- a/lib/XMLArray.php
+++ b/lib/XMLArray.php
@@ -96,6 +96,17 @@ class XMLArray
         $loop = $loopFunction($xmlArray);
 
         return $xmlArray;
+    }    
+
+    /**
+     * @param \Closure $loopFunction
+     * @return mixed
+     */
+    public function loop(\Closure $loopFunction)
+    {
+        $loop = $loopFunction($this);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Hi Aaron,

The problem i was facing is that it was not possible to loop without the start tag. Thats why i created this pull request.

I need to build the XML like this example: https://www.indeed.nl/xml/feed_example.xml
The structure is like:
`<source><job></job><job></job></source>`

When using the startLoop function it will create it like:
`<source><jobs><job></job></jobs></source>`

By merging this pull request it is possible to create the needed structure. In code it will look like the following:
```
$xmlBuilder->createXMLArray()
    ->start('source')
        ->loop(function (XMLArray $XMLArray) use ($jobOffers) {
            foreach ($jobOffers as $jobOffer) {
                $XMLArray->start('job')
                    ->addCData('title', $jobOffer->title)
                    ->addCData('description', $jobOffer->description);
            }
        })
        ->end()
    ->end();
```