### PR TITLE
Allows colons in element data name

### DIFF
--- a/lib/XMLElementData.php
+++ b/lib/XMLElementData.php
@@ -69,7 +69,7 @@ class XMLElementData
      */
     public function setName(string $name): XMLElementData
     {
-        $name = preg_replace('/([^a-zA-Z\-\_]+)/', '', $name);
+        $name = preg_replace('/([^a-zA-Z\-\_\:]+)/', '', $name);
 
         $this->name = $name;
         return $this;


### PR DESCRIPTION
Allowing colons enables generating xml sitemaps for pages with alternate languages as suggested by:
https://developers.google.com/search/docs/advanced/crawling/localized-versions?visit_id=637622978297339966-3027706091&rd=2#sitemap
